### PR TITLE
fix: treeのカードがバグる

### DIFF
--- a/components/TreeComponent.js
+++ b/components/TreeComponent.js
@@ -56,8 +56,10 @@ const pickupCardStyle = makeStyles((theme) => ({
 }))
 
 export const TreeComponent = (tree) => {
-  const cardClasses = (tree.id == tree.source) ? pickupCardStyle() : normalCardStyle();
   const classes = useStyles();
+  const pickupCardClasses = pickupCardStyle();
+  const normalCardClasses = normalCardStyle();
+  const cardClasses = (tree.id == tree.source) ? pickupCardClasses : normalCardClasses;
   const onMediaFallback = event => event.target.src = noImage;
   let avatarChar = tree.hasOwnProperty('author_name') ? tree.author_name.substr(0, 1) : "";
   let mediaURL = typeof tree.thumbnail !== "undefined" ? tree.thumbnail : noImage;


### PR DESCRIPTION
タイトルの通りです．

原因
三項演算子でmakeStyleすると，rootのカードのスタイルしかmakeされない．（オブジェクトが生成されない）
どこかの子で違う方のスタイルを適用してもそのスタイルのオブジェクトが存在しないので，スタイルが適用されず画面幅最大まで広がってしまう．
最初にどっちもオブジェクト作っておくと治った