### PR TITLE
認証画面の各エラー内容をユーザに通知

### DIFF
--- a/components/UserForm.js
+++ b/components/UserForm.js
@@ -122,16 +122,18 @@ const UserForm = ({ isRegister }) => {
             style={{width: '300px', marginTop: '2rem'}}
             onChange={keyHandler}
           /> <br />
-          <CustomTextField
-            id="standard-basic"
-            label="ユーザー名"
-            inputRef={userNameRef}
-            color="primary"
-            inputProps={{ maxLength: 100 }}
-            focused
-            style={{width: '300px', marginTop: '2rem'}}
-            onChange={keyHandler}
-          /> <br />
+          { isRegister && (
+            <CustomTextField
+              id="standard-basic"
+              label="ユーザー名"
+              inputRef={userNameRef}
+              color="primary"
+              inputProps={{ maxLength: 100 }}
+              focused
+              style={{width: '300px', marginTop: '2rem'}}
+              onChange={keyHandler}
+            />
+          )} <br />
           <CustomTextField
             id="standard-basic"
             label="パスワード"

--- a/components/UserForm.js
+++ b/components/UserForm.js
@@ -31,7 +31,7 @@ const UserForm = ({ isRegister }) => {
           console.log(error);
           switch (error.code) {
             case "auth/user-not-found":
-              setError("メールアドレスが登録されていません");
+              setError("このメールアドレスは登録されていません");
               break;
             case "auth/wrong-password":
               setError("パスワードが間違っています");

--- a/components/UserForm.js
+++ b/components/UserForm.js
@@ -91,6 +91,7 @@ const UserForm = ({ isRegister }) => {
       })
       .catch(error => {
         console.log(error);
+        setError("連携に失敗しました");
       })
   };
 

--- a/components/UserForm.js
+++ b/components/UserForm.js
@@ -29,14 +29,18 @@ const UserForm = ({ isRegister }) => {
         })
         .catch(error => {
           console.log(error);
-          if (error.code == "auth/user-not-found") {
-            setError("メールアドレスが登録されていません")
-          } else if (error.code == "auth/wrong-password") {
-            setError("パスワードが間違っています")
-          } else if (error.code == "auth/invalid-email") {
-            setError("無効なメールアドレスです")
-          } else {
-            setError(error.message);
+          switch (error.code) {
+            case "auth/user-not-found":
+              setError("メールアドレスが登録されていません");
+              break;
+            case "auth/wrong-password":
+              setError("パスワードが間違っています");
+              break;
+            case "auth/invalid-email":
+              setError("無効なメールアドレスです");
+              break;
+            default:
+              setError(error.message);
           }
         });
   };
@@ -58,15 +62,18 @@ const UserForm = ({ isRegister }) => {
         })
         .catch(error => {
           console.log(error);
-          console.log("bbbb");
-          if (error.code == "auth/email-already-in-use") {
-            setError("既に登録済みのメールアドレスです");
-          } else if (error.code == "auth/invalid-email") {
-            setError("無効なメールアドレスです")
-          } else if (error.code == "auth/weak-password") {
-            setError("6文字以上のパスワードを設定してください")
-          } else {
-            setError(error.message);
+          switch (error.code) {
+            case "auth/email-already-in-use":
+              setError("既に登録済みのメールアドレスです");
+              break;
+            case "auth/invalid-email":
+              setError("無効なメールアドレスです");
+              break;
+            case "auth/weak-password":
+              setError("6文字以上のパスワードを設定してください");
+              break;
+            default:
+              setError(error.message);
           }
         });
     } else {

--- a/components/UserForm.js
+++ b/components/UserForm.js
@@ -63,6 +63,8 @@ const UserForm = ({ isRegister }) => {
             setError("既に登録済みのメールアドレスです");
           } else if (error.code == "auth/invalid-email") {
             setError("無効なメールアドレスです")
+          } else if (error.code == "auth/weak-password") {
+            setError("6文字以上のパスワードを設定してください")
           } else {
             setError(error.message);
           }

--- a/components/UserForm.js
+++ b/components/UserForm.js
@@ -1,15 +1,18 @@
 import Head from 'next/head';
 import Router from 'next/router';
 import firebase from '../firebase/firebase';
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import { Button, Grid } from '@material-ui/core'
 import { sleep } from '../utils/utils';
 import CustomTextField from '../styles/CustomTextField';
+import Alert from '@material-ui/lab/Alert';
 
 const UserForm = ({ isRegister }) => {
   const emailRef = useRef(null);
   const passwordRef = useRef(null);
   const userNameRef = useRef(null);
+
+  const [errorMessage, setError] = useState([]);
 
   useEffect(() => {
     firebase.auth().onAuthStateChanged(user => {
@@ -25,7 +28,16 @@ const UserForm = ({ isRegister }) => {
           Router.push('/');
         })
         .catch(error => {
-          
+          console.log(error);
+          if (error.code == "auth/user-not-found") {
+            setError("メールアドレスが登録されていません")
+          } else if (error.code == "auth/wrong-password") {
+            setError("パスワードが間違っています")
+          } else if (error.code == "auth/invalid-email") {
+            setError("無効なメールアドレスです")
+          } else {
+            setError(error.message);
+          }
         });
   };
 
@@ -46,6 +58,14 @@ const UserForm = ({ isRegister }) => {
         })
         .catch(error => {
           console.log(error);
+          console.log("bbbb");
+          if (error.code == "auth/email-already-in-use") {
+            setError("既に登録済みのメールアドレスです");
+          } else if (error.code == "auth/invalid-email") {
+            setError("無効なメールアドレスです")
+          } else {
+            setError(error.message);
+          }
         });
     } else {
       await login();
@@ -79,6 +99,7 @@ const UserForm = ({ isRegister }) => {
       </Head>
 	  
       <form className="login">
+        {errorMessage != "" && <Alert severity="error">{errorMessage}</Alert>}
         <h2>{isRegister ? 'アカウントを登録' : 'アカウントにログイン'}</h2>
         <hr />
         <Grid container justify="center" spacing={2}>

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@material-ui/lab": "^4.0.0-alpha.58",
     "draft-js": "^0.11.7",
     "draft-js-export-html": "^1.4.1",
     "next": "^11.0.2-canary.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -506,6 +506,17 @@
   dependencies:
     "@babel/runtime" "^7.4.4"
 
+"@material-ui/lab@^4.0.0-alpha.58":
+  version "4.0.0-alpha.58"
+  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.58.tgz#c7ebb66f49863c5acbb20817163737caa299fafc"
+  integrity sha512-GKHlJqLxUeHH3L3dGQ48ZavYrqGOTXkFkiEiuYMAnAvXAZP4rhMIqeHOPXSUQan4Bd8QnafDcpovOSLnadDmKw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.11.2"
+    clsx "^1.0.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
+
 "@material-ui/styles@^4.11.4":
   version "4.11.4"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.4.tgz#eb9dfccfcc2d208243d986457dff025497afa00d"


### PR DESCRIPTION
- 登録されてない・パスが違うなどのエラーを表示
- ログイン時のユーザ名入力を省略
<img width="454" alt="image" src="https://user-images.githubusercontent.com/49609538/124303235-28747000-db9d-11eb-9e0e-021b3b0a62de.png">

Material UI Labを入れたのでyarn installが必要（多分）
